### PR TITLE
Merge sentry branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,28 +5,47 @@ https://github.com/scottbonline/sense)
 
 0.7.0
 -----
-- add versioneer package to help reduce burden of maintaining any versioning
-  outside of VCS
-- add colorama for ANSI color in cli mode.
+Taiga Items
+***********
+
+TG-12 Add the ability to run sensecli config -e and edit the user config file
+TODO: Add default of print or cat of the config file if -e is not passed as an
+ option
+
+TG-10 fix the incorrect calling of the function.
+
+TG-4 Added sentry configuration to enable and register the sentry sdk if it had
+     been enabled. Also if for someone reason someone wanted to disable or use
+     their own DSN for sentry, that is possible as well.
+
+
+TG-7 add colorama for ANSI color in cli mode.
   todo: add configuration for thresholds and colors for displaying within cli
-- replace pymlconf with the confuse library
-- add realtime property to the api
-- use _<<name>>_ pattern for naming of non-private variable names in api
-- add template with requirements for a user supplied config
-- update to use new configuration library
-- update the readme
+
+TG-6 add versioneer package to help reduce burden of maintaining any versioning
+  outside of VCS
+
+Additional Changes
+******************
+
+  - rename config module to config
+  - import the yaml from config as yamlcfg
+  - replace pymlconf with the confuse library
+  - add realtime property to the api
+  - use _<<name>>_ pattern for naming of non-private variable names in api
+  - add template with requirements for a user supplied config
+  - update to use new configuration library
+  - update the readme
 
 0.6.0
 -----
-- refactor package, rename modules:
-    * cli.py
-    * api.py
-- add yml configuration file
-- start CLI, using click
+  - refactor package, rename modules:
+    - cli.py
+    - api.py
+  - add yml configuration file
+  - start CLI, using click
 
 0.5.0
 -----
-- Adding support for python 3.7.0
-- Add changelog
-
-
+  - Adding support for python 3.7.0
+  - Add changelog

--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ by sscottbonline. Since appears to lost it's mainter, I've forked it here.
 
 ### Todo
 
+- rewrite api.py to reduce boilerplate with fetching the Trend data. Moving to 
+  an object model will simplify tha interface.
 - Continue the development of a fully functional CLI for accessing the APIs:
-  - ensure entry_point is functional
-- Make configuration more flexible: Adding Confuse as the yaml configuration
-  package.
+  - ensure entry_points are functional
 - Add POST/PUT where/if applicable
 - Improved error handling
-- Adding Sentry configuration
+
+#### Completed Todo Items
+- Make configuration more flexible: Adding Confuse as the yaml configuration
+  package. (0.6.0)
+- Adding Sentry configuration (0.7.0)
 
 
 ### Install
@@ -47,7 +51,10 @@ pip install git+https://github.com/sawdog/pysense.git
 ### Setup YAML Config
 
 The configuration uses the standard system config path for the user customized
-configuration.
+configuration. To edit your user configuration run (ensure ENV is setup with 
+EDITOR, GIT_EDITOR or SVN_EDITOR):
+
+> sensecli config -e
 
 The default search paths for each platform:
 

--- a/pysense/__init__.py
+++ b/pysense/__init__.py
@@ -1,4 +1,8 @@
 # a package
 __version__ = "0.7.0"
+from pysense.config import yamlcfg
 
-from .yamlcfg import yamlcfg as config
+if yamlcfg.sentry.enable:
+    import sentry_sdk
+    sentry_sdk.init(yamlcfg.sentry.dsn)
+

--- a/pysense/config.py
+++ b/pysense/config.py
@@ -2,7 +2,14 @@ import confuse
 
 
 config = confuse.LazyConfig('pySense', __name__)
+CONFIG_DIR = config.config_dir()
+USER_CONFIG_PATH = config.user_config_path()
 template = {
+    'logging': {
+        'name': str,
+        'level': str,
+        'propigate': bool,
+    },
     'sense': {
         'username': str,
         'password': str,
@@ -14,10 +21,12 @@ template = {
             'url': str,
         },
     },
+    'sentry': {
+        'enable': bool,
+        'dsn': str
+    },
     'websocket': {
         'timeout': int,
     }
 }
-
-
 yamlcfg = config.get(template)

--- a/pysense/config_default.yaml
+++ b/pysense/config_default.yaml
@@ -1,4 +1,4 @@
-package: sense
+package: pysense
 environment: dev
 handlers:
      date:
@@ -9,8 +9,9 @@ handlers:
          arrow_format: "YYYY/MM/DD HH:mm:ss"
          default_format:  "%%Y/%%m/%%d %%H:%%M:%%S"
 logging:
-  name: sense
+  name: pysense
   level: INFO
+  propigate: False
 sense:
   username: None
   password: None
@@ -19,5 +20,8 @@ sense:
     timeout: 5
   realtime:
     url: wss://clientrt.sense.com/monitors/%s/realtimefeed?access_token=%s
+sentry:
+  enable: True
+  dsn:  https://0fc969d48fa04a04a914ba0c4f8172e1@sentry.io/1304672
 websocket:
   timeout: 5

--- a/pysense/utils.py
+++ b/pysense/utils.py
@@ -1,0 +1,60 @@
+import os
+import logging
+
+from pysense.config import (yamlcfg,
+                            USER_CONFIG_PATH,
+                            )
+
+
+log = logging.getLogger(yamlcfg.logging.name)
+if not log.handlers:
+    log.setLevel(yamlcfg.logging.level)
+    log.addHandler(logging.StreamHandler())
+    log.propagate = yamlcfg.logging.propigate
+
+
+
+# grab the environment var for the users editor
+def get_editor():
+    """return the editor command or raise Exception:
+
+       look in the environment for either EDITOR, GIT_EDITOR or SVN_EDITOR
+
+       if not found, raise error EDITOR needs to be set in the env
+
+    """
+    found = os.environ.get('EDITOR',
+                            os.environ.get('GIT_EDITOR',
+                                           os.environ.get('SVN_EDITOR')))
+    if not found:
+        msg = 'You must set your editor in your environment. Either ' \
+              '"EDITOR", "GIT_EDITOR" or "SVN_EDITOR" ' 'must be set.'
+        raise Exception(msg)
+
+    return found
+
+
+def edit_config():
+    """open the configuration file for editing"""
+    command = get_editor()
+    try:
+        if not os.path.isfile(USER_CONFIG_PATH):
+            open(USER_CONFIG_PATH, 'w+').close()
+
+        edit(USER_CONFIG_PATH, command)
+    except OSError as e:
+        msg = u"Could not edit configuration: {0}".format(e)
+        raise Exception(msg)
+
+
+def edit(config_dir, command):
+    """edit the configuration file"""
+    args = str.split(command)
+    args.insert(0, args[0])  # for argv[0]
+    args += [config_dir]
+
+    return os.execlp(*args)
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'colorama',
         'confuse',
         'requests',
-        'versioneer',
+        'sentry-sdk',
         'websocket-client',
     ],
     version=versioneer.get_version(),


### PR DESCRIPTION
TG-10 #closed
  - Fixed the bug in get_all_usage_data
TG-12 #closed
  - Add the ability to run sensecli config -e and edit the user config
    file
TG-10 #closed
  - fix the incorrect calling of the function.
TG-4 #closed
  - Added sentry configuration to enable and register the sentry sdk if
    it had been enabled. Also if for someone reason someone wanted to
    disable or use their own DSN for sentry, that is possible as well.
TG-7 #closed
  - add colorama
TG-6 #closed
  - Add versioneer to project
Additional Changes
  - Add new utils module for helpful things
  - Add sentry configuration and setup in package init
  - Rename config module
  - import configuration as yamlcfg
  - Add active handler in the api module, so there's only a single handler
    to look up the key from the realtime json dictionary.
  - Rename the get_discovered_device_data to devices_map - which is more
    representative of what's being returned. It's details about all
    devices; planning to add a flag to the cli and have it be an option
    of the devices endpoint (see TG-11)
  - import the yaml from config as yamlcfg
  - replace pymlconf with the confuse library
  - add realtime property to the api
  - use _<<name>>_ pattern for naming of non-private variable names in api
  - add template with requirements for a user supplied config
  - update to use new configuration library
  - update the readme